### PR TITLE
correct update from unpackaged

### DIFF
--- a/postgis/build/postgis-2.5.4/extensions/postgis/Makefile.in
+++ b/postgis/build/postgis-2.5.4/extensions/postgis/Makefile.in
@@ -81,10 +81,10 @@ sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql | sql
 
 sql/$(EXTENSION)--unpackaged--$(EXTVERSION).sql: $(EXTENSION_UNPACKAGED_UPGRADE_SCRIPTS) sql/$(EXTENSION)--ANY--$(EXTVERSION).sql ../../utils/create_unpackaged.pl Makefile | sql
 	# Ensure version is correct
-	cat sql/$(EXTENSION)--ANY--$(EXTVERSION).sql > $@
 	cat $(EXTENSION_UNPACKAGED_UPGRADE_SCRIPTS) \
 		| $(PERL) ../../utils/create_unpackaged.pl postgis \
-		>> $@
+		> $@
+	cat sql/$(EXTENSION)--ANY--$(EXTVERSION).sql >> $@
 
 unpackaged_check.sql: unpackaged_check.sql.in Makefile
 	cat $< \


### PR DESCRIPTION
since https://github.com/greenplum-db/gpdb/commit/ecc2f0b2b7a11ab137078db3383d7245771df21a postgis does not correct update from unpackaged because it first do `create or replace objects` and second do `alter extension add` causing follow errors
```sql
create extension postgis;
ERROR:  PostGIS is already installed in schema 'public'

create extension postgis from unpackaged;
ERROR:  function _postgis_deprecate(text,text,text) is not a member of extension "postgis"
DETAIL:  An extension is not allowed to replace an object that it does not own.
```
solution consists in first do `alter extension add` and second do `create or replace objects`